### PR TITLE
Fix for NetOutputStreamUDT write function

### DIFF
--- a/barchart-udt-core/src/main/java/com/barchart/udt/net/NetOutputStreamUDT.java
+++ b/barchart-udt-core/src/main/java/com/barchart/udt/net/NetOutputStreamUDT.java
@@ -1,10 +1,3 @@
-/**
- * Copyright (C) 2009-2012 Barchart, Inc. <http://www.barchart.com/>
- *
- * All rights reserved. Licensed under the OSI BSD License.
- *
- * http://www.opensource.org/licenses/bsd-license.php
- */
 package com.barchart.udt.net;
 
 import java.io.IOException;
@@ -57,21 +50,25 @@ public class NetOutputStreamUDT extends OutputStream {
 	public void write(final byte[] bytes, final int off, final int len)
 			throws IOException {
 
-		final int count = socketUDT.send(bytes, off, off + len);
-
-		if (count > 0) {
-			assert count == len;
-			return;
+		int bytesRemaining = len;
+		
+		while(bytesRemaining > 0){
+			
+			final int count = socketUDT.send(bytes, off + len - bytesRemaining , off + len);
+			
+			if (count > 0) {
+				bytesRemaining -= count;													
+				continue;
+			}			
+			
+			if (count == 0) {
+				throw new ExceptionSendUDT(socketUDT.getSocketId(),
+						ErrorUDT.USER_DEFINED_MESSAGE, "UDT send time out");
+			}			
+			
+			throw new IllegalStateException("Socket has been chaged to non-blocking");			
 		}
-
-		if (count == 0) {
-			throw new ExceptionSendUDT(socketUDT.getSocketId(),
-					ErrorUDT.USER_DEFINED_MESSAGE, "UDT send time out");
-
-		}
-
-		throw new IllegalStateException("should not happen");
-
+				
 	}
 
 	@Override


### PR DESCRIPTION
UDT::write function is not guaranteed to send all data in one go, especially if there is no UDT buffer space left for the socket.  This will retry the remaining data, which will then usually block until buffer space becomes available
