### PR TITLE
Fix for issue #56

### DIFF
--- a/barchart-udt-core/src/main/c++/jni/com_barchart_udt_SocketUDT.cpp
+++ b/barchart-udt-core/src/main/c++/jni/com_barchart_udt_SocketUDT.cpp
@@ -1376,7 +1376,8 @@ JNIEXPORT jint JNICALL Java_com_barchart_udt_SocketUDT_send1( //
 			if (UDT::ERROR
 					== (ss = UDT::send(socketID, (char*) (data + ssize),
 							size - ssize, 0))) {
-				printf("send: %s\n", UDT::getlasterror().getErrorMessage());
+				printf("send: %s\n", UDT::getlasterror().getErrorMessage());		
+				ssize = ss;
 				break;
 			}
 			ssize += ss;


### PR DESCRIPTION
send1 should now throw an exception when a socket error occurs when sending data over a UDT SOCK_STREAM socket
