### PR TITLE
byte is a signed type in java, so we need to mask it with &0xFF

### DIFF
--- a/barchart-udt-core/src/main/java/com/barchart/udt/net/NetInputStreamUDT.java
+++ b/barchart-udt-core/src/main/java/com/barchart/udt/net/NetInputStreamUDT.java
@@ -64,7 +64,7 @@ public class NetInputStreamUDT extends InputStream {
 
 		assert count == 1;
 
-		return data[0];
+		return data[0] & 0xFF;
 
 	}
 


### PR DESCRIPTION
for more details, see
http://stackoverflow.com/questions/11380062/what-does-value-0xff-do-in-java

pretty weird, that such a "bug" is still existing

the "int read()" method of NetInputStreamUDT should not return a negative value, since it is interpreted as an EOF
the java byte type can have values from -128 .. +127
so 50% of all byte values do convert to a negative integer, which results in an EOF Exception in some circumstances

for example if you use the readInt method of DataInputStream
http://docs.oracle.com/javase/7/docs/api/java/io/DataInputStream.html#readInt()

the code looks like this: 

```
public final int readInt() throws IOException {
        int ch1 = in.read();
        int ch2 = in.read();
        int ch3 = in.read();
        int ch4 = in.read();
        if ((ch1 | ch2 | ch3 | ch4) < 0)
            throw new EOFException();
        return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
    }
```

the chance is pretty high to get an EOFException...
BTW: it took my a lot of time to find this one. But i do not want to complain :-) 
the project is gorgeous, thanks a lot
